### PR TITLE
Warning: ReactDOM.render is no longer supported fix

### DIFF
--- a/src/frontend/index.tsx
+++ b/src/frontend/index.tsx
@@ -113,38 +113,37 @@ const AppRoot = () => {
                 url: 'https://mor.org',
                 base64Icon: LOGO_METAMASK_BASE64,
               },
+
               modals: {
                 install: ({ link }) => {
                   let modalContainer: HTMLElement;
 
                   return {
                     mount: () => {
-                      if (modalContainer) return;
-
                       modalContainer = document.createElement('div');
 
                       modalContainer.id = 'meta-mask-modal-container';
 
                       document.body.appendChild(modalContainer);
 
-                      ReactDOM.render(
+                      const modalRoot = createRoot(modalContainer);
+
+                      modalRoot.render(
                         <QrCodeModal
                           onClose={() => {
-                            ReactDOM.unmountComponentAtNode(modalContainer);
+                            modalRoot.unmount();
                             modalContainer.remove();
                           }}
                         />,
-                        modalContainer,
                       );
 
                       setTimeout(() => {
                         updateQrCode(link);
                       }, 100);
                     },
+
                     unmount: () => {
                       if (modalContainer) {
-                        ReactDOM.unmountComponentAtNode(modalContainer);
-
                         modalContainer.remove();
                       }
                     },


### PR DESCRIPTION
This PR includes a fix for issue #47 

-  fix for ReactDOM.render which is no longer supported in React 18
- Showing QR code modal as long as the wallet is not connected




https://github.com/MorpheusAIs/Node/assets/68545109/1f16331b-5a31-48bc-a750-e847593d8a68

