### PR TITLE
update windows config to remove loadingGif default in squirrel

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -63,6 +63,7 @@ const config: ForgeConfig = {
   makers: [
     new MakerSquirrel({
       setupIcon: 'src/frontend/assets/images/circle-mor-logo.ico',
+      loadingGif: 'undefined', // Disable the loading GIF
     }),
     new MakerZIP({}, ['darwin']),
     new MakerRpm({}),


### PR DESCRIPTION
added configuration line to makers for forge.config.ts which causes the option for loadingGif to be undefined and therefore no gif is seen in install or loading.